### PR TITLE
Clean up lambda expressions in StorageTest.java

### DIFF
--- a/src/test/java/aladdin/StorageTest.java
+++ b/src/test/java/aladdin/StorageTest.java
@@ -68,21 +68,21 @@ public class StorageTest {
     @Test
     public void deserialiseTask_invalidTodo_exceptionThrown() {
         assertThrows(ArrayIndexOutOfBoundsException.class,
-                () -> { Storage.deserialiseTask("T|0"); }
+                () -> Storage.deserialiseTask("T|0")
         );
     }
 
     @Test
     public void deserialiseTask_invalidDeadline_exceptionThrown() {
         assertThrows(ArrayIndexOutOfBoundsException.class,
-                () -> { Storage.deserialiseTask("D|0|deadline task"); }
+                () -> Storage.deserialiseTask("D|0|deadline task")
         );
     }
 
     @Test
     public void deserialiseTask_invalidEvent_exceptionThrown() {
         assertThrows(ArrayIndexOutOfBoundsException.class,
-                () -> { Storage.deserialiseTask("E|1|event task|6-8-2026 1400"); }
+                () -> Storage.deserialiseTask("E|1|event task|6-8-2026 1400")
         );
     }
 


### PR DESCRIPTION
JUnit test in StorageTest.java uses lambda expressions with curly braces.

Curly braces for single line lambda expressions are unnecessary.

Let's,
* remove curly braces in lambda expressions

This makes the code cleaner and ensures consistency.